### PR TITLE
Sponsors page

### DIFF
--- a/client/app/main/main.controller.js
+++ b/client/app/main/main.controller.js
@@ -12,4 +12,13 @@ angular.module('observatory3App')
     $http.get('/api/static').success(function(stats) {
       $scope.statics = stats;
     });
+
+    $scope.sponsors = [
+      { name: 'RedHat', logo: 'http://logo-load.com/uploads/posts/2016-02/1456126060_logo-red-hat.png', alt: 'Red Hat Linux', url: 'https://www.redhat.com/', description: 'RedHat has funded student projects and learning workshops, including Introduction to Open Source Software.' },
+      { name: 'Mozilla', logo: 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d2/Mozilla_logo.svg/2000px-Mozilla_logo.svg.png', alt: 'Mozilla', url: 'https://www.mozilla.org/en-US/foundation/', description: 'Helped with leadership program for mentors.' },
+      { name: 'Open Source Initiative', logo: 'https://opensource.org/files/osi_standard_logo.png', alt: 'Open Source Initiative', url: 'https://opensource.org/', description: 'Educational Institution Member that has provided opportunities for students.' },
+      { name: 'NSF HFOSS', logo: 'http://www.hfoss.org/uploads/images/allgray_notrinity.gif', alt: 'HFOSS', url: 'http://www.hfoss.org/index.php/contact-us', description: 'Affliated member with Trinity, Connecticut College and Wesleyan University' },
+      { name: 'Microsoft', logo: 'https://mtaiit.com/imgs/microsoft.png', alt: 'Microsoft', url: 'https://www.microsoft.com/en-us/', description: 'Partially Funded Student projects (through Microsoft employee program).' },
+      { name: 'Google', logo: 'https://cdn.vox-cdn.com/uploads/chorus_asset/file/6466217/fixed-google-logo-font.png', alt: 'Google', url: 'https://www.google.com/', description: 'Donated MAGPis and Cardboard VR.' }
+    ]
 });

--- a/client/app/main/main.html
+++ b/client/app/main/main.html
@@ -100,7 +100,7 @@
         <div class="panel-body">
           <dl class="dl-horizontal">
             <dt>Tuesday (4:00-5:15)</dt>
-            <dd>Small group meetings in <a target="_blank" href="https://docs.google.com/spreadsheets/d/17zsTufmlryzPQGGkgfArOs1i_pWGypTY_sn1B-9gnqI/edit?usp=sharing">these rooms</a></dd>
+            <dd>Small group meetings in <a target="_blank" href="https://docs.google.com/spreadsheets/d/1T9BwAAjFSxKj0gzuKMaIg1aRAZUqsuRSJyTtrk9GrcM/edit?usp=sharing">these rooms</a></dd>
             <dt>Friday (4:00-5:15)</dt>
             <dd>Large group meetings in DCC 318</dd>
           </dl>

--- a/client/app/main/main.js
+++ b/client/app/main/main.js
@@ -8,5 +8,10 @@ angular.module('observatory3App')
         templateUrl: 'app/main/main.html',
         controller: 'MainController',
         controllerAs: 'main'
-      });
+      })
+      .state('sponsors', {
+        url: '/sponsors',
+        templateUrl: 'app/main/sponsors.html',
+        controller: 'MainController'
+      })
   });

--- a/client/app/main/main.less
+++ b/client/app/main/main.less
@@ -71,3 +71,25 @@ body {
   }
 
 }
+
+// Sponsors
+.row.sponsors-wrapper {
+  margin-top: 4rem;
+
+  .sponsor-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 2rem;
+    justify-content: space-between;
+
+    .img-thumbnail {
+      max-height: 10rem;
+    }
+
+    .sponsor-name {
+      margin-top: 3rem;
+    }
+
+  }
+}

--- a/client/app/main/sponsors.html
+++ b/client/app/main/sponsors.html
@@ -1,0 +1,33 @@
+<!--Above banner login and home navigation bar-->
+<div ng-include="'components/navbar/navbar.html'"></div>
+
+<!--Top of Page Banner-->
+<header class="hero-unit" id="banner">
+  <div class="container">
+    <h1>Rensselaer Center for Open Source</h1>
+    <p class="lead">Sponsors</p>
+  </div>
+</header>
+
+<!-- Page Content -->
+<div class="container">
+  <div class="row sponsors-wrapper">
+    <div class="col-sm-12 col-md-3 sponsor-col" ng-repeat="sponsor in sponsors">
+
+      <a ng-href="{{sponsor.url}}" target="_blank">
+        <img class="img-thumbnail" ng-src="{{sponsor.logo}}" ng-alt="{{sponsor.alt}}">
+      </a>
+
+      <p class="lead sponsor-name">
+        {{ sponsor.name }}
+      </p>
+
+      <p class='text-center sponsor-description'>
+        {{ sponsor.description }}
+      </p>
+
+    </div>
+  </div>
+</div>
+
+<div ng-include="'components/footer/footer.html'"></div>


### PR DESCRIPTION
Added a basic sponsors page to hold us over until `observatory-client` is ready for prime-time. Also updated the `Small Groups` google spreadsheet link. Fully resolves [#674](https://github.com/rcos/observatory-server/issues/674)
![rcos sponsors page](https://user-images.githubusercontent.com/4616233/37739797-c11d82a6-2d31-11e8-8bd3-b815ae939f89.png)
